### PR TITLE
Escape message body

### DIFF
--- a/Sources/ExampleRun/main.swift
+++ b/Sources/ExampleRun/main.swift
@@ -1,3 +1,3 @@
-import App
+import ExampleApp
 
 try app(.detect()).run()

--- a/Sources/Twilio/Extensions/String+XMLEscaped.swift
+++ b/Sources/Twilio/Extensions/String+XMLEscaped.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+extension String {
+    var xmlEscaped: String {
+        return replacingOccurrences(of: "&", with: "&amp;")
+            .replacingOccurrences(of: "\"", with: "&quot;")
+            .replacingOccurrences(of: "'", with: "&#39;")
+            .replacingOccurrences(of: ">", with: "&gt;")
+            .replacingOccurrences(of: "<", with: "&lt;")
+    }
+}

--- a/Sources/Twilio/TWIML/SMSResponse.swift
+++ b/Sources/Twilio/TWIML/SMSResponse.swift
@@ -15,7 +15,7 @@ public struct Message: Verb {
         return """
         <Message>
             <Body>
-                \(body)
+                \(body.xmlEscaped)
             </Body>
         </Message>
         """

--- a/Tests/TwilioTests/TWIMLTests.swift
+++ b/Tests/TwilioTests/TWIMLTests.swift
@@ -69,4 +69,22 @@ final class TWIMLTests: XCTestCase {
         
         XCTAssertEqual(smsResponseWithMessage.generateTwiml(), expectedTwiml)
     }
+    
+    func testSMSResponseForEscapedBody() throws {
+        let message = Message(body: "enemy<goblin>")
+        let smsResponseWithMessage = SMSResponse(message)
+        
+        let expectedTwiml = """
+        <?xml version="1.0" encoding="UTF-8" ?>
+        <Response>
+            <Message>
+            <Body>
+                enemy&lt;goblin&gt;
+            </Body>
+        </Message>
+        </Response>
+        """
+        
+        XCTAssertEqual(smsResponseWithMessage.generateTwiml(), expectedTwiml)
+    }
 }


### PR DESCRIPTION
Fixes a bug where message bodies weren't being XML escaped, so if you had a body that looked like "enemy<goblin>", twilio would interpret that as a malformed tag. We're now escaping message bodies.