### PR TITLE
Method to lookup for a phone number

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,19 @@ public func configure(_ app: Application) throws {
 }
 ```
 
+### Lookup phone number
+
+```swift
+import Twilio
+
+func routes(_ app: Application) throws {
+    app.get("lookup") { req -> EventLoopFuture<LookupResponse> in
+        let phoneNumber = "+18316100806"
+        return req.twilio.lookup(phoneNumber)
+    }
+}
+```
+
 ### Handling Incoming Texts
 After [setting up the necessary routing within your Twilio account](https://www.twilio.com/docs/sms/twiml#twilios-request-to-your-application), you may create routes to handle and respond to incoming texts.
 

--- a/Sources/ExampleApp/routes.swift
+++ b/Sources/ExampleApp/routes.swift
@@ -11,6 +11,11 @@ func routes(_ app: Application) throws {
         return req.twilio.send(sms)
     }
 
+    app.get("lookup") { req -> EventLoopFuture<LookupResponse> in
+        let phoneNumber = "+41 (0) 79 226 42 28"//"+18316100806"
+        return req.twilio.lookup(phoneNumber)
+    }
+
     app.post("incoming") { req -> Response in
         let sms = try req.content.decode(IncomingSMS.self)
 

--- a/Sources/ExampleApp/routes.swift
+++ b/Sources/ExampleApp/routes.swift
@@ -12,7 +12,7 @@ func routes(_ app: Application) throws {
     }
 
     app.get("lookup") { req -> EventLoopFuture<LookupResponse> in
-        let phoneNumber = "+41 (0) 79 226 42 28"//"+18316100806"
+        let phoneNumber = "+18316100806"
         return req.twilio.lookup(phoneNumber)
     }
 

--- a/Sources/Twilio/Models/CarrierResponse.swift
+++ b/Sources/Twilio/Models/CarrierResponse.swift
@@ -8,6 +8,6 @@ public struct CarrierResponse: Content {
         case voip
     }
 
-    let name: String
-    let type: CarrierType
+    public let name: String
+    public let type: CarrierType
 }

--- a/Sources/Twilio/Models/CarrierResponse.swift
+++ b/Sources/Twilio/Models/CarrierResponse.swift
@@ -2,7 +2,7 @@ import Vapor
 
 public struct CarrierResponse: Content {
 
-    enum CarrierType: String, Codable {
+    public enum CarrierType: String, Codable {
         case mobile
         case landline
         case voip

--- a/Sources/Twilio/Models/CarrierResponse.swift
+++ b/Sources/Twilio/Models/CarrierResponse.swift
@@ -1,0 +1,13 @@
+import Vapor
+
+public struct CarrierResponse: Content {
+
+    enum CarrierType: String, Codable {
+        case mobile
+        case landline
+        case voip
+    }
+
+    let name: String
+    let type: CarrierType
+}

--- a/Sources/Twilio/Models/LookupResponse.swift
+++ b/Sources/Twilio/Models/LookupResponse.swift
@@ -1,8 +1,8 @@
 import Vapor
 
 public struct LookupResponse: Content {
-    let countryCode: String
-    let phoneNumber: String
-    let nationalFormat: String
-    let carrier: CarrierResponse
+    public let countryCode: String
+    public let phoneNumber: String
+    public let nationalFormat: String
+    public let carrier: CarrierResponse
 }

--- a/Sources/Twilio/Models/LookupResponse.swift
+++ b/Sources/Twilio/Models/LookupResponse.swift
@@ -1,0 +1,8 @@
+import Vapor
+
+public struct LookupResponse: Content {
+    let countryCode: String
+    let phoneNumber: String
+    let nationalFormat: String
+    let carrier: CarrierResponse
+}


### PR DESCRIPTION
Twilio offers an endpoint to lookup phone numbers. https://www.twilio.com/docs/lookup/quickstart

A new method `lookup(number:)` in the Twilio module will use the Twilio Endpoint to lookup the given phone number.

```swift
import Twilio

func routes(_ app: Application) throws {
    app.get("lookup") { req -> EventLoopFuture<LookupResponse> in
        let phoneNumber = "+18316100806"
        return req.twilio.lookup(phoneNumber)
    }
}
```

If successful, the `LoopupResponse` will look like this:
```json
{
    "countryCode": "US",
    "nationalFormat": "(831) 610-0806",
    "carrier": {
        "name": "Twilio - Inteliquent - SMS-Sybase365/MMS-SVR",
        "type": "voip"
    },
    "phoneNumber": "+18316100806"
}
```

The `carrier.type` can either be `voip`, `mobile` or `landline`. Which is very handy to check if a number can receive SMS.